### PR TITLE
feat: add python context queries

### DIFF
--- a/runtime/queries/python/context.scm
+++ b/runtime/queries/python/context.scm
@@ -1,0 +1,15 @@
+(function_definition
+  _ parameters: (_) @context.params
+) @context
+
+(class_definition) @context
+
+[
+  (if_statement)
+  (for_statement)
+  (while_statement)
+  (with_statement)
+  (try_statement)
+  (match_statement)
+  (case_clause)
+] @context


### PR DESCRIPTION
Hi,

Just a little contribution, as I work mostly with Python.

This adds context queries for the sticky-context feature, so python classes and functions show up as well

My first attempt at those queries, might not be entirely right yet, but seems to work on my machine :tm: 