### PR TITLE
Add c-sharp sticky context queries

### DIFF
--- a/runtime/queries/c-sharp/context.scm
+++ b/runtime/queries/c-sharp/context.scm
@@ -1,51 +1,51 @@
 ; Credits to nvim-treesitter-context
 
 (interface_declaration
-  body: (_) @context.end
+  body: (_) @context.params
 ) @context
 
 (class_declaration
-  body: (_) @context.end
+  body: (_) @context.params
 ) @context
 
 (enum_declaration
-  body: (_) @context.end
+  body: (_) @context.params
 ) @context
 
 (struct_declaration
-  body: (_) @context.end
+  body: (_) @context.params
 ) @context
 
 (record_declaration
-  body: (_) @context.end
+  body: (_) @context.params
 ) @context
 
 (namespace_declaration
-  body: (_) @context.end
+  body: (_) @context.params
 ) @context
 
 (constructor_declaration
-  body: (_) @context.end
+  body: (_) @context.params
 ) @context
 
 (destructor_declaration
-  body: (_) @context.end
+  body: (_) @context.params
 ) @context
 
 (method_declaration
-  body: (_) @context.end
+  body: (_) @context.params
 ) @context
 
 (switch_statement
-  body: (_) @context.end
+  body: (_) @context.params
 ) @context
 
 (for_statement
-  body: (_) @context.end
+  body: (_) @context.params
 ) @context
 
 (if_statement
-  consequence: (_) @context.end
+  consequence: (_) @context.params
 ) @context
 
 ([
@@ -54,11 +54,11 @@
 ] @context)
 
 (try_statement
-  body: (_) @context.end
+  body: (_) @context.params
 ) @context
 
 (catch_clause
-  body: (_) @context.end
+  body: (_) @context.params
 ) @context
 
 (finally_clause) @context

--- a/runtime/queries/c-sharp/context.scm
+++ b/runtime/queries/c-sharp/context.scm
@@ -1,0 +1,64 @@
+; Credits to nvim-treesitter-context
+
+(interface_declaration
+  body: (_) @context.end
+) @context
+
+(class_declaration
+  body: (_) @context.end
+) @context
+
+(enum_declaration
+  body: (_) @context.end
+) @context
+
+(struct_declaration
+  body: (_) @context.end
+) @context
+
+(record_declaration
+  body: (_) @context.end
+) @context
+
+(namespace_declaration
+  body: (_) @context.end
+) @context
+
+(constructor_declaration
+  body: (_) @context.end
+) @context
+
+(destructor_declaration
+  body: (_) @context.end
+) @context
+
+(method_declaration
+  body: (_) @context.end
+) @context
+
+(switch_statement
+  body: (_) @context.end
+) @context
+
+(for_statement
+  body: (_) @context.end
+) @context
+
+(if_statement
+  consequence: (_) @context.end
+) @context
+
+([
+  (do_statement)
+  (while_statement)
+] @context)
+
+(try_statement
+  body: (_) @context.end
+) @context
+
+(catch_clause
+  body: (_) @context.end
+) @context
+
+(finally_clause) @context

--- a/runtime/queries/c-sharp/context.scm
+++ b/runtime/queries/c-sharp/context.scm
@@ -1,64 +1,43 @@
 ; Credits to nvim-treesitter-context
 
-(interface_declaration
-  body: (_) @context.params
-) @context
+(interface_declaration) @context
 
-(class_declaration
-  body: (_) @context.params
-) @context
+(class_declaration) @context
 
-(enum_declaration
-  body: (_) @context.params
-) @context
+(enum_declaration) @context
 
-(struct_declaration
-  body: (_) @context.params
-) @context
+(struct_declaration) @context
 
-(record_declaration
-  body: (_) @context.params
-) @context
+(record_declaration) @context
 
-(namespace_declaration
-  body: (_) @context.params
-) @context
+(namespace_declaration) @context
 
 (constructor_declaration
-  body: (_) @context.params
-) @context
+    (parameter_list) @context.params
+  ) @context
 
 (destructor_declaration
-  body: (_) @context.params
-) @context
+    (parameter_list) @context.params
+  ) @context
 
 (method_declaration
-  body: (_) @context.params
-) @context
+    (parameter_list) @context.params
+  ) @context
 
-(switch_statement
-  body: (_) @context.params
-) @context
+(switch_statement) @context
 
-(for_statement
-  body: (_) @context.params
-) @context
+(for_statement) @context
 
-(if_statement
-  consequence: (_) @context.params
-) @context
+(if_statement) @context
 
 ([
   (do_statement)
   (while_statement)
 ] @context)
 
-(try_statement
-  body: (_) @context.params
-) @context
+(try_statement) @context
 
-(catch_clause
-  body: (_) @context.params
-) @context
+(catch_clause) @context
 
 (finally_clause) @context
+


### PR DESCRIPTION
C# sticky context tested & works
----
- Also, do you plan to tweak & keep sticky context feature up to date?
- I wish we can show tree sitter sticky context on picker preview. Use case is simple: [LSP] Pick references of the function -> Modal Picker with N use cases. If context/body function of the preview at the right side is pretty long, then you can't see in modal preview name of the parent function/class, in which the function you are looking for is used. So i guess modal picker preview with sticky context can be very powerful, mb toggle behavior like cfg flag. Let me know what you think, if we can work on this feature 